### PR TITLE
Refactor hsv_picker

### DIFF
--- a/main.c
+++ b/main.c
@@ -52,10 +52,10 @@ int main(void)
     hsv_picker_init(INITIAL_HSV_HUE, INITIAL_HSV_SATURATION, INITIAL_HSV_BRIGHTNESS);
 
     /* Making hsv_picker_next_mode function to be called on double click of a button */
-    button_subscribe_for_state(BUTTON_PRESSED_TWICE_RECENTLY, hsv_picker_next_mode);
+    button_subscribe_to_SW1_state(BUTTON_PRESSED_TWICE_RECENTLY, hsv_picker_next_mode);
 
     /* Making hsv_picker_edit_param function to be called on hold of a SW1 button */
-    button_subscribe_for_hold(hsv_picker_edit_param);
+    button_subscribe_to_SW1_hold(hsv_picker_edit_param);
 
     /* Toggle LEDs. */
     while (true)

--- a/modules/gpio/button/board_button.c
+++ b/modules/gpio/button/board_button.c
@@ -111,7 +111,7 @@ button_recent_state_t button_get_recent_state(board_button_t button)
 	return BUTTON_UNKNOWN_RECENT_STATE;
 }
 
-void button_subscribe_for_state(button_recent_state_t state, button_clicks_subscriber_t handler)
+void button_subscribe_to_SW1_state(button_recent_state_t state, button_clicks_subscriber_t handler)
 {
 	NRFX_ASSERT(state < BUTTON_RECENT_STATES_NUMBER);
 	NRFX_ASSERT(handler != NULL);
@@ -133,7 +133,7 @@ void button_subscribe_for_state(button_recent_state_t state, button_clicks_subsc
 	clicks_subscribers_idxs[state]++;
 }
 
-void button_subscribe_for_hold(button_hold_subscriber_t handler)
+void button_subscribe_to_SW1_hold(button_hold_subscriber_t handler)
 {
 	NRFX_ASSERT(handler != NULL);
 

--- a/modules/gpio/button/board_button.h
+++ b/modules/gpio/button/board_button.h
@@ -36,9 +36,9 @@ uint32_t button_is_pressed(board_button_t button);
 button_recent_state_t button_get_recent_state(board_button_t button);
 
 /* Will try to add a subscriber for some recent state */
-void button_subscribe_for_state(button_recent_state_t state, button_clicks_subscriber_t handler);
+void button_subscribe_to_SW1_state(button_recent_state_t state, button_clicks_subscriber_t handler);
 
 /* Will try to add a subscriber for hold of a button (SW1) */
-void button_subscribe_for_hold(button_hold_subscriber_t handler);
+void button_subscribe_to_SW1_hold(button_hold_subscriber_t handler);
 
 #endif

--- a/modules/hsv/hsv_helper.c
+++ b/modules/hsv/hsv_helper.c
@@ -9,31 +9,6 @@ float hsv_helper_modf(float value, float mod_base)
 	return value - (mod_base * floorf(value / mod_base));
 }
 
-static float hsv_helper_absf(float value)
-{
-	if (value < 0.0F)
-	{
-		return -value;
-	}
-
-	return value;
-}
-
-static uint16_t hsv_helper_float_to_uint16(float value, uint16_t max_value)
-{
-	float max_value_f = (float)max_value;
-	if (value > max_value_f || max_uint16_f < value)
-	{
-		return max_value;
-	}
-	if (value < 0.0F)
-	{
-		return 0U;
-	}
-
-	return (uint16_t)((unsigned int)(floorf(value)));
-}
-
 static void hsv_helper_align_hsv(hsv_ctx_t *hsv)
 {
 	if (hsv->hue > HSV_MAX_HUE)
@@ -50,6 +25,31 @@ static void hsv_helper_align_hsv(hsv_ctx_t *hsv)
 	{
 		hsv->brightness = HSV_MAX_BRIGHTNESS;
 	}
+}
+
+uint16_t hsv_helper_float_to_uint16(float value, uint16_t max_value)
+{
+	float max_value_f = (float)max_value;
+	if (value > max_value_f || max_uint16_f < value)
+	{
+		return max_value;
+	}
+	if (value < 0.0F)
+	{
+		return 0U;
+	}
+
+	return (uint16_t)((unsigned int)(floorf(value)));
+}
+
+float hsv_helper_absf(float value)
+{
+	if (value < 0.0F)
+	{
+		return -value;
+	}
+
+	return value;
 }
 
 void hsv_helper_convert(hsv_ctx_t *hsv, rgb_value_t *res)

--- a/modules/hsv/hsv_helper.h
+++ b/modules/hsv/hsv_helper.h
@@ -27,4 +27,8 @@ void hsv_helper_convert(hsv_ctx_t *hsv, rgb_value_t *rgb);
 
 float hsv_helper_modf(float value, float mod_base);
 
+uint16_t hsv_helper_float_to_uint16(float value, uint16_t max_value);
+
+float hsv_helper_absf(float value);
+
 #endif

--- a/modules/hsv/hsv_picker.h
+++ b/modules/hsv/hsv_picker.h
@@ -13,10 +13,23 @@ typedef enum
 	HSV_PICKER_MODE_EDIT_BRIGHTNESS
 } hsv_picker_mode_t;
 
+/*
+	Initialize hsv_picker & start playing given hsv value according to the given values
+*/
 void hsv_picker_init(float initial_hue, float initial_saturation, float initial_brightness);
 
+/*
+	Change mode of hsv_picker.
+	1) HSV_PICKER_MODE_VIEW            -> 2
+	2) HSV_PICKER_MODE_EDIT_HUE        -> 3
+	3) HSV_PICKER_MODE_EDIT_SATURATION -> 4
+	4) HSV_PICKER_MODE_EDIT_BRIGHTNESS -> 1
+*/
 void hsv_picker_next_mode(void);
 
+/*
+	Changes hue, saturation or birghtness according to the current mode of hsv_picker.
+*/
 void hsv_picker_edit_param(void);
 
 #endif


### PR DESCRIPTION
**Goal**: control LEDs in hsv_picker using only 1 PWM instance.

**Done**:
 - Add function to generate PWM values of indicator LED;
 - Remove PWM instance which was used to control indicator LED;
 - Remove extra configs of PWM instances;