### PR TITLE
Remove app_usbd_cdc_acm_t from arguments list of hsv cli handlers

### DIFF
--- a/armgcc/Makefile
+++ b/armgcc/Makefile
@@ -75,6 +75,7 @@ SRC_FILES += \
   $(PROJ_DIR)/utils/generator/sinusoid.c \
   $(PROJ_DIR)/utils/generator/fcyclic_variable.c \
   $(PROJ_DIR)/modules/cli_errors/cli_errors.c \
+  $(PROJ_DIR)/modules/cli_errors/cli_described_result.c \
   $(PROJ_DIR)/modules/cdc_acm/cdc_acm_read_buf.c \
   $(PROJ_DIR)/modules/cdc_acm/cdc_acm.c \
   $(PROJ_DIR)/modules/cdc_acm/cdc_acm_cli.c \

--- a/modules/cdc_acm/cdc_acm_cli.c
+++ b/modules/cdc_acm/cdc_acm_cli.c
@@ -33,22 +33,25 @@ static void cdc_acm_cli_handle_event_with_prompt(cdc_acm_cli_event_t event)
 	{
 		cdc_acm_cli_event_handler_t handler = handlers[event];
 
-		estc_cli_error_t err = handler(&cdc_acm_cli, &acm_read_buffer);
+		estc_cli_described_result_t result = handler(&acm_read_buffer);
 
-		if (err == ESTC_CLI_ERROR_EMPTY_COMMAND)
+		if (result.error == ESTC_CLI_ERROR_EMPTY_COMMAND)
 		{
 			return;
 		}
 
-		char *error_str = estc_cli_errors_stringify(err);
-		char prompt[100] = {'\0'};
+		char prompt[560] = {0};
 		size_t max_len = sizeof(prompt) - 1;
 
-		strncat(prompt, error_str, max_len);
-		if (strlen(error_str) + 3 < max_len)
+		result.result_describer(result.error, prompt);
+		if (max_len - 3 < strlen(prompt)) 
 		{
-			max_len -= (strlen(error_str) + 1);
-			strncat(prompt, "\r\n", max_len);
+			prompt[max_len - 3] = '\r';
+			prompt[max_len - 2] = '\n';
+		}
+		else
+		{
+			strncat(prompt, "\r\n", 3);
 		}
 
 		cdc_acm_write(&cdc_acm_cli, prompt, strlen(prompt));

--- a/modules/cdc_acm/cdc_acm_cli.h
+++ b/modules/cdc_acm/cdc_acm_cli.h
@@ -1,7 +1,7 @@
 #ifndef CDC_ACM_CLI_H
 #define CDC_ACM_CLI_H
 
-#include "modules/cli_errors/cli_errors.h"
+#include "modules/cli_errors/cli_described_result.h"
 #include "cdc_acm.h"
 #include "app_config.h"
 
@@ -50,7 +50,7 @@ typedef enum
  * 
  * @param[in] read_buf Input which may be processed by the handler.
 */
-typedef estc_cli_error_t (*cdc_acm_cli_event_handler_t)(app_usbd_cdc_acm_t const *cdc_acm, cdc_acm_read_buf_t *read_buf);
+typedef estc_cli_described_result_t (*cdc_acm_cli_event_handler_t)(cdc_acm_read_buf_t *read_buf);
 
 /**
  * @brief Register cdc acm instance.

--- a/modules/cli_errors/cli_described_result.c
+++ b/modules/cli_errors/cli_described_result.c
@@ -1,0 +1,9 @@
+#include <string.h>
+#include "cli_described_result.h"
+
+void estc_cli_describe_error(estc_cli_error_t error, char buffer[512])
+{
+	char * error_description = estc_cli_errors_stringify(error);
+	memset(buffer, '\0', 512);
+	memcpy(buffer, error_description, 511);
+}

--- a/modules/cli_errors/cli_described_result.h
+++ b/modules/cli_errors/cli_described_result.h
@@ -3,11 +3,11 @@
 
 #include "cli_errors.h"
 
-typedef void ( * estc_cli_result_describer_t(estc_cli_error_t error, char buffer[512]) );
+typedef void ( * estc_cli_result_describer_t )(estc_cli_error_t error, char buffer[512]);
 
 typedef struct
 {
-	estc_cli_described_result_t result_describer;
+	estc_cli_result_describer_t result_describer;
 	estc_cli_error_t            error;
 } estc_cli_described_result_t;
 

--- a/modules/cli_errors/cli_described_result.h
+++ b/modules/cli_errors/cli_described_result.h
@@ -1,0 +1,16 @@
+#ifndef ESTC_CLI_DESCRIBED_RESULT_H
+#define ESTC_CLI_DESCRIBED_RESULT_H
+
+#include "cli_errors.h"
+
+typedef void ( * estc_cli_result_describer_t(estc_cli_error_t error, char buffer[512]) );
+
+typedef struct
+{
+	estc_cli_described_result_t result_describer;
+	estc_cli_error_t            error;
+} estc_cli_described_result_t;
+
+void estc_cli_describe_error(estc_cli_error_t error, char buffer[512]);
+
+#endif

--- a/modules/hsv/cli/cli.c
+++ b/modules/hsv/cli/cli.c
@@ -16,18 +16,20 @@
 #define HSV_CLI_MAX_WORD_SIZE ESTC_MAX_LINE_SIZE
 #endif
 
-estc_cli_error_t hsv_cli_exec_command(app_usbd_cdc_acm_t const *cdc_acm,
-						  cdc_acm_read_buf_t *read_buf)
+estc_cli_described_result_t hsv_cli_exec_command(cdc_acm_read_buf_t *read_buf)
 {
 	char args[HSV_CLI_MAX_ARGS + 1][HSV_CLI_MAX_WORD_SIZE] = {0};
 	size_t nargs = utils_strings_tokenize(args, read_buf->buf, " \r\n\t\0");
 
 	if (nargs == 0)
 	{
-		return ESTC_CLI_ERROR_EMPTY_COMMAND;
+		return (estc_cli_described_result_t) {
+			.error = ESTC_CLI_ERROR_EMPTY_COMMAND,
+			.result_describer = estc_cli_describe_error,
+		};
 	}
 	
 	hsv_cli_command_t cmd = hsv_cli_resolve_command(args[0]);
 	
-	return hsv_cli_exec_handler(cmd, cdc_acm, args + 1, nargs - 1);
+	return hsv_cli_exec_handler(cmd, args + 1, nargs - 1);
 }

--- a/modules/hsv/cli/cli.h
+++ b/modules/hsv/cli/cli.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <app_usbd_cdc_acm.h>
-#include "modules/cli_errors/cli_errors.h"
+#include "modules/cli_errors/cli_described_result.h"
 #include "modules/cdc_acm/cdc_acm_read_buf.h"
 
 /**
@@ -14,10 +14,8 @@
  *          and executes this command (all words except the first word from the 
  *          { read_buf } are treated as arguments of the command).
  * 
- * @param[in] cdc_acm Registered cdc acm instance where output will be written.
- * 
  * @param[in] read_buf Buffer from where command and its arguments may be parsed. 
 */
-estc_cli_error_t hsv_cli_exec_command(app_usbd_cdc_acm_t const *cdc_acm, cdc_acm_read_buf_t *read_buf);
+estc_cli_described_result_t hsv_cli_exec_command(cdc_acm_read_buf_t *read_buf);
 
 #endif // HSV_CLI_H

--- a/modules/hsv/cli/cli_handlers.c
+++ b/modules/hsv/cli/cli_handlers.c
@@ -8,6 +8,11 @@
 #include "hsv_picker.h"
 #include "hsv_saved_colors.h"
 
+#ifndef ESTC_CLI_HELP_HEADER
+#define ESTC_CLI_HELP_HEADER "List of available commands:\r\n" \
+                             "help - print information about available commands\r\n"
+#endif
+
 static hsv_cli_command_handler_get command_handlers[] =
 {
 	HSV_CLI_HANDLERS(HSV_CLI_EXECUTORS_EXPAND_AS_INTERFACE)
@@ -25,26 +30,35 @@ static const char *hsv_cli_get_cmd_str(hsv_cli_command_t h)
 	return handler.command_name();
 }
 
-static void hsv_cli_exec_help(estc_cli_error_t error, char buffer[512])
+static void hsv_cli_exec_help(estc_cli_error_t error, char help_prompt[512])
 {
-	char help_prompt[512] = "List of available commands:\r\n"
-							"help - print information about available commands\r\n";		
-	int max_len = sizeof(help_prompt) - strlen(help_prompt) - 1;
+	memset(help_prompt, 0, 512);
+	strncat(help_prompt, ESTC_CLI_HELP_HEADER, 511);
+	size_t max_len = 511UL - strlen(help_prompt);
 
 
-	for (int i = 0; i < HSV_CLI_COMMAND_HELP && max_len > 0; i++)
+	for (int i = 0; i < HSV_CLI_COMMAND_HELP; i++)
 	{
 		hsv_cli_handler_i handler = (*command_handlers[i])();
 		const char *command_prompt = handler.help();
 
+		if (max_len < strlen(command_prompt))
+		{
+			break;
+		}
+
 		strncat(help_prompt, command_prompt, max_len);
 		max_len -= strlen(command_prompt);
+
+		if (max_len < 3UL)
+		{
+			break;
+		}
+
 		strncat(help_prompt, "\r\n", max_len);
 		max_len -= 2;
 	}
-	help_prompt[sizeof(help_prompt) - 1] = '\0';
-
-	memcpy(buffer, help_prompt, 512);
+	help_prompt[511] = '\0';
 }
 
 hsv_cli_command_t hsv_cli_resolve_command(const char *command)

--- a/modules/hsv/cli/cli_handlers.h
+++ b/modules/hsv/cli/cli_handlers.h
@@ -5,7 +5,7 @@
 #include <stdint.h>
 #include "app_config.h"
 
-#include "modules/cli_errors/cli_errors.h"
+#include "modules/cli_errors/cli_described_result.h"
 #include "cli/handlers/include/cli_add_current_color.h"
 #include "cli/handlers/include/cli_add_rgb_color.h"
 #include "cli/handlers/include/cli_apply_color.h"
@@ -59,17 +59,14 @@ hsv_cli_command_t hsv_cli_resolve_command(const char *command);
 /**
  * @brief Executes handler of a command if it exists with passed arguments.
  * 
- * @param[in] h enumerator decribing command handler.
- * 
- * @param[in] cdc_acm Registered cdc acm instance where the output will be written.
+ * @param[in] h enumerator decribing command handler
  * 
  * @param[in] args Arguments of the command (without command name).
  * 
  * @param[in] nargs Number of arguments.
 */
-estc_cli_error_t hsv_cli_exec_handler(hsv_cli_command_t h,
-						             app_usbd_cdc_acm_t const *cdc_acm,
-						             char args[][HSV_CLI_MAX_WORD_SIZE],
-						             uint8_t nargs);
+estc_cli_described_result_t hsv_cli_exec_handler(hsv_cli_command_t h,
+						                         char args[][HSV_CLI_MAX_WORD_SIZE],
+						                         uint8_t nargs);
 
 #endif

--- a/modules/hsv/cli/handlers/cli_add_current_color.c
+++ b/modules/hsv/cli/handlers/cli_add_current_color.c
@@ -35,7 +35,7 @@ estc_cli_error_t hsv_cli_handler_add_current_color(char args[][HSV_CLI_MAX_WORD_
 
 const char *hsv_cli_handler_add_current_color_help(void)
 {
-	return "add_current_color <color_name> - save currently displayed color";
+	return "add_current_color <name> - save current color";
 }
 
 const char *hsv_cli_handler_add_current_color_name(void)

--- a/modules/hsv/cli/handlers/cli_add_rgb_color.c
+++ b/modules/hsv/cli/handlers/cli_add_rgb_color.c
@@ -31,8 +31,8 @@ estc_cli_error_t hsv_cli_handler_add_rgb_color(char args[][HSV_CLI_MAX_WORD_SIZE
 
 const char *hsv_cli_handler_add_rgb_color_help(void)
 {
-	return "add_rgb_color <red> <green> <blue> <color_name> - "
-	       "save red, green, blue combination under color_name";
+	return "add_rgb_color <R> <G> <B> <name> - "
+	       "save red, green, blue combination";
 }
 
 const char *hsv_cli_handler_add_rgb_color_name(void)

--- a/modules/hsv/cli/handlers/cli_apply_color.c
+++ b/modules/hsv/cli/handlers/cli_apply_color.c
@@ -41,7 +41,7 @@ estc_cli_error_t hsv_cli_handler_apply_color(char args[][HSV_CLI_MAX_WORD_SIZE],
 
 const char *hsv_cli_handler_apply_color_help(void)
 {
-	return "apply_color <color_name> - try applying color saved as <color_name>";
+	return "apply_color <name> - try applying saved color";
 }
 
 const char *hsv_cli_handler_apply_color_name(void)

--- a/modules/hsv/cli/handlers/cli_delete_color.c
+++ b/modules/hsv/cli/handlers/cli_delete_color.c
@@ -35,7 +35,7 @@ estc_cli_error_t hsv_cli_handler_delete_color(char args[][HSV_CLI_MAX_WORD_SIZE]
 
 const char *hsv_cli_handler_delete_color_help(void)
 {
-	return "del_color <color_name> - delete already saved color";
+	return "del_color <name> - delete saved color";
 }
 
 const char *hsv_cli_handler_delete_color_name(void)

--- a/modules/hsv/cli/handlers/cli_update_hsv.c
+++ b/modules/hsv/cli/handlers/cli_update_hsv.c
@@ -31,7 +31,7 @@ estc_cli_error_t hsv_cli_handler_update_hsv(char args[][HSV_CLI_MAX_WORD_SIZE],
 
 const char *hsv_cli_handler_update_hsv_help(void)
 {
-	return "hsv <hue> <saturation> <brightness> - set hue, saturation, and brightness of RGB LEDs";
+	return "hsv <H> <S> <B> - set hue, saturation, and brightness";
 }
 
 const char *hsv_cli_handler_update_hsv_name(void)

--- a/modules/hsv/cli/handlers/cli_update_rgb.c
+++ b/modules/hsv/cli/handlers/cli_update_rgb.c
@@ -29,7 +29,7 @@ estc_cli_error_t hsv_cli_handler_update_rgb(char args[][HSV_CLI_MAX_WORD_SIZE],
 
 const char *hsv_cli_handler_update_rgb_help(void)
 {
-	return "rgb <red> <green> <blue> - set values of RGB LEDs";
+	return "rgb <R> <G> <B> - set red, green, blue, values";
 }
 
 const char *hsv_cli_handler_update_rgb_name(void)


### PR DESCRIPTION
Add:
 - estc_cli_described_result_t struct which contains error code and a pointer to a function which describes result of execution of the handler

Modify:
 - Help messages of handlers
 - Cdc_acm_cli event handler now operates on estc_cli_described_result_t
 - hsv_cli_exec_handler now returns estc_cli_described_result_t
 - hsv_cli_exec_help is result descriptor now 